### PR TITLE
allow usage with python 2 by changing shebang line

### DIFF
--- a/bin/ansishell
+++ b/bin/ansishell
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 from ansible import inventory
 import subprocess
 import configparser


### PR DESCRIPTION
Reference "python" instead of "python3" in shebang declaration to allow use with python2 installation.
Unfortunately I was not able to test this change on a python3-only-system.